### PR TITLE
Two typos and a minor correction.

### DIFF
--- a/projects/walkies/README.md
+++ b/projects/walkies/README.md
@@ -60,9 +60,9 @@ The `endl` is doing two things for you:
 1. Of course, it's giving you a new line but it is also...
 2. Triggers the output to actually render on your console
 
-Actual output via streams like `cout` and `cerr` only happens
-when new lines are emitted. This is called "buffering". Buffering is
-a powerful technique to increase efficiency when:
+Actual output via streams like `cout` only happens when new lines are
+emitted. This is called "buffering". Buffering is a powerful technique
+to increase efficiency when:
 
 * the amount of output is a little at a time
 
@@ -87,7 +87,10 @@ The choice of the method name `flush()` is apropos in that you're
 "flushing" any buffered characters all the way to their ultimate end
 point.
 
-Note that `cout` can be replaced with the name of any output stream.
+Note that `cout` can be replaced with the name of any output stream. Though
+observe that its counterpart `cerr`, which is intended for diagnostics and
+error reporting, does not use a buffer so that important messages are reported
+immediately. As a result, there is never any need to call `cerr.flush()`.
 
 ## Forcing Output In Assembly Language
 

--- a/section_2/float/what.md
+++ b/section_2/float/what.md
@@ -46,7 +46,7 @@ Equation:           1 x 2^0                  1 x 2^0
 ```
 
 On the line marked "Value" you can see the values represented as double precision 
-and as single precious. Under "Comment" you can see that there
+and as single precision. Under "Comment" you can see that there
 is no difference between the double and the single precision numbers. Remember
 the key thing about floating point numbers: they are approximations. Sometimes,
 as in the case of whole numbers like 1, the approximation is exact. When there

--- a/section_3/bitfields/README.md
+++ b/section_3/bitfields/README.md
@@ -356,7 +356,7 @@ size of data structures in memory and on disc.
 
 ## Space Versus Time
 
-In Computer Science there is an eternal between space and time. The
+In Computer Science there is an eternal tension between space and time. The
 following is a **law**:
 
 *If you want something to go faster, it will cost more memory.*


### PR DESCRIPTION
[As it turns out](https://en.cppreference.com/w/cpp/io/basic_ostream), `std::cerr` and `std::wcerr` are the only global `std::ostream`s provided by the standard library that aren't buffered.

Thanks again! I'm having a great time with your projects and trying to write faster code than LLVM. It's cause for celebration when I succeed.